### PR TITLE
add pulp_content_app

### DIFF
--- a/pulp3/install_pulp3/source-install-plugins.yml
+++ b/pulp3/install_pulp3/source-install-plugins.yml
@@ -42,3 +42,4 @@
     - pulp3-workers
     - pulp3-resource-manager
     - pulp3-webserver
+    - pulp3-content

--- a/pulp3/install_pulp3/source-install.yml
+++ b/pulp3/install_pulp3/source-install.yml
@@ -17,3 +17,4 @@
     - pulp3-workers
     - pulp3-resource-manager
     - pulp3-webserver
+    - pulp3-content


### PR DESCRIPTION
There is a new role `pulp3-content` missing on pulp3 installer playbooks.

* probably the cause of 9 failures on CI