### PR TITLE
Fix plugin app labels

### DIFF
--- a/pulp3/install_pulp3/source-install-plugins.yml
+++ b/pulp3/install_pulp3/source-install-plugins.yml
@@ -10,13 +10,13 @@
     pulp_pip_editable: no
     pulp_install_plugins:
       pulp-file:
-        app_label: "pulp_file"
+        app_label: "file"
         source_dir: "https://github.com/pulp/pulp_file/tarball/master"
       pulp-rpm:
-        app_label: "pulp_rpm"
+        app_label: "rpm"
         source_dir: "https://github.com/pulp/pulp_rpm/tarball/master"
       pulp-docker:
-        app_label: "pulp_docker"
+        app_label: "docker"
         source_dir: "https://github.com/pulp/pulp_docker/tarball/master"
   pre_tasks:
     - name: Install pulp rpm requirements

--- a/pulp3/install_pulp3/source-install.yml
+++ b/pulp3/install_pulp3/source-install.yml
@@ -10,7 +10,7 @@
     pulp_pip_editable: no
     pulp_install_plugins:
       pulp-file:
-        app_label: "pulp_file"
+        app_label: "file"
         source_dir: "https://github.com/pulp/pulp_file/tarball/master"
   roles:
     - pulp3-postgresql


### PR DESCRIPTION
The PR https://github.com/pulp/pulp/pull/3836/ removed the `pulp_`
prefix from app labels.

So commands like `pulp-manager makemigrations pulp_file` are now
`pulp-manager makemigrations file`