### PR TITLE
Fix postgres install and add certguard plugin

### DIFF
--- a/pulp3/install_pulp3/README.md
+++ b/pulp3/install_pulp3/README.md
@@ -1,72 +1,59 @@
 # Install pulp3 using the ansible installer
 
-This recipes uses https://github.com/pulp/ansible-pulp3 roles to install Pulp 3 in a Fedora 28|29 server.
-
-## Install Pulp 3 with only the pulp_file plugin
+This recipes uses https://github.com/pulp/ansible-pulp3 roles to install Pulp 3 in a Fedora 28+ server.
 
 ### Curl installer
+
+> Installs using ansible-pulp3 roles and playbooks from github
 
 ```bash
 export PULP3_HOST=<hotname or IP>
 curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/install.sh | bash
 ```
 
+> NOTE: The above by default installs with **rpm, file, docker and certguard** plugins. To install only core `export PULP3_PLAYBOOK=source-install.yml` use this same variable to specify a custom playbook.
+
 ### Manually
 
-Get the roles and install it
+> Installs using local ansible-pulp3 roles and local playbooks
+
+Clone the ansible-pulp3 roles locally (skip if you already have it)
 
 ```bash
-git clone https://github.com/pulp/ansible-pulp3.git
+git clone https://github.com/pulp/ansible-pulp3.git /path/to/ansible-pulp3/
 ```
 
-Apply some workarounds for known issues
-
-``` bash
-# pip should be updated
-# FIXME: installer should take care of it.
-sed -i -e "s/- name: Install pulpcore package from source/- name: Upgrade pip\n      pip:\n        name: pip\n        state: latest\n        virtualenv_command: '{{ pulp_python_interpreter }} -m venv'\n        virtualenv: '{{pulp_install_dir}}'\n\n    - name: Install pulpcore package from source/g" ./ansible-pulp3/roles/pulp3/tasks/install.yml
-
-```
-
-Install the roles
-
-```bash
-export ANSIBLE_ROLES_PATH="./ansible-pulp3/roles/"
-ansible-galaxy install -r ./ansible-pulp3/requirements.yml
-ansible-galaxy list
-```
-
-Clone this repository and run the playbook
+Clone this repository locally
 
 ```bash
 git clone https://github.com/PulpQE/pulp-qe-tools.git
 cd pulp-qe-tools/pulp3/install_pulp3/
-
-export ANSIBLE_ROLES_PATH="./ansible-pulp3/roles/"
-ansible-playbook -v -i <hostname or IP>, -u root source-install.yml
 ```
 
-## Install with all the plugins
+Configure some environment variables
 
-To install with all the set of plugins `rpm, file, docker`.
-
-### Curl installer
+**Required**
 
 ```bash
+# Where to install
 export PULP3_HOST=<hotname or IP>
-export PULP3_PLAYBOOK=source-install-plugins.yml
-curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/install.sh | bash
+# Set to use local playbooks (not from github)
+export PULP3_INSTALL_MODE=local
 ```
 
-### Manually
-
-Follow the same steps for manual installation described above replacing the ansible-playbook with:
+**Optional**
 
 ```bash
-...
-export ANSIBLE_ROLES_PATH="./ansible-pulp3/roles/"
-ansible-playbook -v -i <hostname or IP>, -u root source-install-plugins.yml
+# To install only core change the playbook
+# or use a custom playbook name
+export PULP3_PLAYBOOK=source-install.yml  
+
+# Where did you cloned ansible-pulp3 (otherwise will fetch from github)
+export PULP3_ROLES_PATH=/path/to/ansible-pulp3/
 ```
 
+Install it
 
-> NOTE: Currently the installation with all the plugins is failing. Take a look at `traceback.log` file.
+```bash
+./install.sh
+```

--- a/pulp3/install_pulp3/install.sh
+++ b/pulp3/install_pulp3/install.sh
@@ -4,11 +4,28 @@
 # export PULP3_PLAYBOOK=source-install-plugins.yml
 # curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/install.sh | bash
 
+# Optionally if you clone the qe-tools and want to use local playboks
+# export PULP3_INSTALL_MODE=local
+# export PULP3_HOST=myhostname.com
+# export PULP3_PLAYBOOK=source-install-plugins.yml
+# export PULP3_ROLES_PATH=/path/to/local/ansible-pulp3 (optional)
+# ./install.sh
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 HOST="${PULP3_HOST:-$(hostname)}"
 echo "Installing on host: ${HOST} - set PULP3_HOST env var to override it"
 
-PLAYBOOK="${PULP3_PLAYBOOK:-source-install.yml}"
+PLAYBOOK="${PULP3_PLAYBOOK:-source-install-plugins.yml}"
 echo "Will use: ${PLAYBOOK} - set PULP3_PLAYBOOK env var to override it"
+
+# wether we get the playbooks from qe-tools repo or use the local one
+INSTALL_MODE="${PULP3_INSTALL_MODE:-github}"
+echo "Will install from ${INSTALL_MODE} - set PULP3_INSTALL_MODE=local|github env var to override it"
+
+# Where the roles are located? if empty will fetch from github
+ROLES_PATH="${PULP3_ROLES_PATH:-github}"
+echo "Will use ${ROLES_PATH} roles - set PULP3_ROLES_PATH=/path/to/ansible-pulp3/ env var to override it"
 
 # requirements
 if ! git --version > /dev/null; then
@@ -40,18 +57,29 @@ fi
 tempdir="$(mktemp --directory)"
 pushd "${tempdir}"
 
-git clone https://github.com/pulp/ansible-pulp3.git
+if [ "$INSTALL_MODE" == "github" ]; then
+  # get the playbook locally
+  echo "Fetching playbook from github"
+  curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/ansible.cfg > ansible.cfg
+  curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/"${PLAYBOOK}" > install.yml
+else
+  # For local debugging uncomment this line
+  echo "Using local repo playbook"
+  cp "$DIR"/ansible.cfg ansible.cfg
+  cp "$DIR"/"${PLAYBOOK}" install.yml
+fi
 
-# get the playbook locally
-curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/ansible.cfg > ansible.cfg
-curl https://raw.githubusercontent.com/PulpQE/pulp-qe-tools/master/pulp3/install_pulp3/"${PLAYBOOK}" > install.yml
-
-# For local debugging uncomment this line
-# cp ~/Projects/pulp/pulp-qe-tools/pulp3/install_pulp3/"${PLAYBOOK}" install.yml
+if [ "$ROLES_PATH" == "github" ]; then
+    echo "Fetching ansible installer roles from github"
+    git clone https://github.com/pulp/ansible-pulp3.git
+else
+    echo "Using local roles from $ROLES_PATH"
+    cp -R "$ROLES_PATH" ./ansible-pulp3
+fi
 
 echo "Installing roles."
 export ANSIBLE_ROLES_PATH="./ansible-pulp3/roles/"
-ansible-galaxy install -r ./ansible-pulp3/requirements.yml
+ansible-galaxy install -r ./ansible-pulp3/requirements.yml --force
 
 echo "Available roles."
 ansible-galaxy list

--- a/pulp3/install_pulp3/source-install-plugins.yml
+++ b/pulp3/install_pulp3/source-install-plugins.yml
@@ -3,7 +3,9 @@
 - hosts: all
   vars:
     ansible_python_interpreter: /usr/bin/python3
-    pulp_source_dir: "https://github.com/pulp/pulpcore/tarball/master"
+    pulp_source_dir: 
+        - "https://github.com/pulp/pulpcore/tarball/master"
+        - psycopg2-binary
     pulp_plugin_source_dir: "https://github.com/pulp/pulpcore-plugin/tarball/master"
     pulp_secret_key: "unsafe_default"
     pulp_default_admin_password: admin
@@ -18,6 +20,9 @@
       pulp-docker:
         app_label: "docker"
         source_dir: "https://github.com/pulp/pulp_docker/tarball/master"
+      pulp-certguard:
+        app_label: "certguard"
+        source_dir: "https://github.com/pulp/pulp-certguard/tarball/master"
   pre_tasks:
     - name: Install pulp rpm requirements
       package: name={{item}} state=present

--- a/pulp3/install_pulp3/source-install.yml
+++ b/pulp3/install_pulp3/source-install.yml
@@ -3,7 +3,9 @@
 - hosts: all
   vars:
     ansible_python_interpreter: /usr/bin/python3
-    pulp_source_dir: "https://github.com/pulp/pulpcore/tarball/master"
+    pulp_source_dir: 
+        - "https://github.com/pulp/pulpcore/tarball/master"
+        - psycopg2-binary
     pulp_plugin_source_dir: "https://github.com/pulp/pulpcore-plugin/tarball/master"
     pulp_secret_key: "unsafe_default"
     pulp_default_admin_password: admin


### PR DESCRIPTION
Postgres installation was failing by the lack of psycopg2
added it to pulp_source_dir, which by ansible docs can be a list

> Note: added to tlist because on pip module we cannot pass extra requires when using git url.

plus:

- Improve `install.sh` script with more env vars to allow local file uses
- Improve README

Depends on https://github.com/pulp/pulp-certguard/pull/6