### PR TITLE
Firewalld cannot be masked because iptables may start/stop it.

### DIFF
--- a/pulp3/install_pulp3/source-install-plugins.yml
+++ b/pulp3/install_pulp3/source-install-plugins.yml
@@ -49,8 +49,8 @@
     - pulp3-webserver
     - pulp3-content
   post_tasks:
-    - name: Stop Firewalld
+    - name: Disable Firewalld
       systemd:
         name: firewalld
         state: stopped
-        masked: yes
+        enabled: False

--- a/pulp3/install_pulp3/source-install.yml
+++ b/pulp3/install_pulp3/source-install.yml
@@ -21,8 +21,8 @@
     - pulp3-webserver
     - pulp3-content
   post_tasks:
-    - name: Stop Firewalld
+    - name: Disable Firewalld
       systemd:
         name: firewalld
         state: stopped
-        masked: yes
+        enabled: False


### PR DESCRIPTION
Iptables is failing when setting networok on libvirt because it can' t start/stop firewalld