### PR TITLE
Add DJANGO_SETTINGS_MODULE to pulp3 installer script

### DIFF
--- a/pulp3/install_pulp3/source-install-plugins.yml
+++ b/pulp3/install_pulp3/source-install-plugins.yml
@@ -48,6 +48,8 @@
     - pulp-resource-manager
     - pulp-webserver
     - pulp-content
+  environment:
+    DJANGO_SETTINGS_MODULE: pulpcore.app.settings
   post_tasks:
     - name: Disable Firewalld
       systemd:

--- a/pulp3/install_pulp3/source-install.yml
+++ b/pulp3/install_pulp3/source-install.yml
@@ -20,6 +20,8 @@
     - pulp-resource-manager
     - pulp-webserver
     - pulp-content
+  environment:
+    DJANGO_SETTINGS_MODULE: pulpcore.app.settings
   post_tasks:
     - name: Disable Firewalld
       systemd:


### PR DESCRIPTION
Recent change on pulp removed the pulp-manager and now is using
`django-admin` command, that command requires DJANGO_SETTINGS_MODULE envvar