### PR TITLE
Add pulp_ansible plugin to the installer

### DIFF
--- a/pulp3/install_pulp3/install.sh
+++ b/pulp3/install_pulp3/install.sh
@@ -55,6 +55,10 @@ fi
 
 # make a temp dir to clone all the things
 tempdir="$(mktemp --directory)"
+
+# make pulpenv.sh available on tmpdir
+cp ./pulpenv.sh "${tempdir}"/
+
 pushd "${tempdir}"
 
 if [ "$INSTALL_MODE" == "github" ]; then

--- a/pulp3/install_pulp3/pulpenv.sh
+++ b/pulp3/install_pulp3/pulpenv.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+PYTHONDIR="/usr/local/lib/pulp/bin"
+
+if [ "${#@}" -eq 0 ]; then
+    CMD="source $PYTHONDIR/activate"
+else
+    CMD="$PYTHONDIR/$@"
+fi
+
+sudo -u pulp /bin/bash -c "DJANGO_SETTINGS_MODULE=pulpcore.app.settings $CMD; DJANGO_SETTINGS_MODULE=pulpcore.app.settings exec /bin/bash -i"
+

--- a/pulp3/install_pulp3/source-install-plugins.yml
+++ b/pulp3/install_pulp3/source-install-plugins.yml
@@ -23,6 +23,9 @@
       pulp-certguard:
         app_label: "certguard"
         source_dir: "https://github.com/pulp/pulp-certguard/tarball/master"
+      pulp-ansible:
+        app_label: "ansible"
+        source_dir: "https://github.com/pulp/pulp_ansible/tarball/master"
   pre_tasks:
     - name: Install pulp rpm requirements
       package: name={{item}} state=present
@@ -56,3 +59,8 @@
         name: firewalld
         state: stopped
         enabled: False
+    - name: Allow the use of `$ pulpenv` to activate pulp python env
+      copy:
+        src: pulpenv.sh
+        dest: /bin/pulpenv
+        mode: preserve


### PR DESCRIPTION
## Adds  puilp_ansible to the installer playbook

- plus: It also adds the `$ pulpenv` as alias to activate pulp3 virtual env

```bash
$ pulpenv
(pulp)  # on activated pulp3 virtualenv
django-admin
dynaconf list
pulp-content

and other commands works without extra work.
```

and it also works for direct commands

```bash
$ pulpenv pip install pulp_foo
$ pulpenv django-admin makemigrations
$ pulpenv django-admin migrate foo

```