### PR TITLE
Update python interpreter used by Ansible

### DIFF
--- a/pulp3/install_pulp3/install.sh
+++ b/pulp3/install_pulp3/install.sh
@@ -123,7 +123,6 @@ ansible-playbook -v -c "${ANSIBLE_CONNECTION}" -i "${HOST}", -u root install.yml
   -e pulp_api_bind=0.0.0.0:"${HOST_PORT}" \
   -e plugins_list="${PLUGINS}" \
   -e install_dev_tools="${DEV_TOOLS}" \
-  -e ansible_python_interpreter="/usr/bin/python"
 
 echo "Cleaning."
 popd


### PR DESCRIPTION
Update interpreter used by Ansible. Few packages related to python2 are
being removed from the latest fedora releases.

See: https://github.com/ansible/ansible/issues/54855

A more robust is to use auto discovery of the interpreter. To be added
later, and update the CI properly.

https://docs.ansible.com/ansible/latest/reference_appendices/interpreter_discovery.html#interpreter-discovery.