### PR TITLE
introduce pulp docker repo inspector

### DIFF
--- a/pulp2/tools/pulp-docker-inspector/README.rst
+++ b/pulp2/tools/pulp-docker-inspector/README.rst
@@ -1,0 +1,73 @@
+pulp-docker-inspector
+=====================
+
+pulp-docker-inspector is a tool to map the relationships between content in a pulp docker
+repository. It has 2 modes, `list` and `relation`.
+
+List
+****
+
+Print the relationships heirarchy (top down) between content in the specified pulp repo.
+
+.. code-block:: bash
+
+   $ python pulp-docker-inspector.py test-fixture-1 --list
+
+Partial Output::
+
+   REPO: test-fixture-1
+   TAG: manifest_b
+       MANIFEST: sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0
+           BLOB: sha256:df5f2171d7a00260c6910231fd760f7b7d2afa576d1f2a674bf84496f1374e76
+           BLOB: sha256:59add7b26d3a179ea3f653e7d4bb81250611f1408eb1effb2e50631a9da145c4
+   TAG: manifest_a
+       MANIFEST: sha256:04c27eb360809e1ea49c97fe8b8ca21d9f0ca7eb1be98030d1b539a76613470d
+           BLOB: sha256:686209d53cbd832d0c9a5f77ae8acf87c58f7880581cf132f4022857d23e9182
+           BLOB: sha256:242bb0431e380347dc02cecc616037a003d9ba9e1ae2fd62a3a874e4bdda1baf
+   TAG: manifest_d
+       MANIFEST: sha256:5921794fc03cba2162b314eea4755d074e06528a073ee4ab8cc54954dc7e0d89
+           BLOB: sha256:357aff548189b13f3803b0ecf9c755eea235b89de0baa2838b10f7ff6217db13
+           BLOB: sha256:0eccceb6824ea1a7e9a55ffe1145917af90a267e19324a178a659fe9cb0c6f8f
+   TAG: manifest_c
+       MANIFEST: sha256:6bda89d0d0772b03e4afb615e771b1c4ed8e76895ede8d7eede9b041ea4507e8
+           BLOB: sha256:be6e7d2ac7b720bdc7aeacbc214a4587fb751509e04b12d9b20929c306b39401
+   TAG: ml_iii
+       MANIFESTLIST: sha256:c981478019c48aa00aa839ef5a73f551db0f9900fc2b1bd44b193c79dc3fe88b
+           MANIFEST: sha256:04c27eb360809e1ea49c97fe8b8ca21d9f0ca7eb1be98030d1b539a76613470d
+               BLOB: sha256:686209d53cbd832d0c9a5f77ae8acf87c58f7880581cf132f4022857d23e9182
+               BLOB: sha256:242bb0431e380347dc02cecc616037a003d9ba9e1ae2fd62a3a874e4bdda1baf
+           MANIFEST: sha256:d86b32899d0b6a0048e89dbf80fc8f673d2b262bbb22be6c6a780426d8539bae
+               BLOB: sha256:be6e7d2ac7b720bdc7aeacbc214a4587fb751509e04b12d9b20929c306b39401
+               BLOB: sha256:53519986d08c36bf136346b7435f95eac3dd6901eacdb7b7404a60caf5058419
+
+Relation
+********
+
+Determine sharing relationships for a given manifest or manifest-list digest.
+
+.. code-block:: bash
+
+   $ python pulp-docker-inspector.py test-fixture-1 --relation sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0
+
+Partial Output::
+
+   ********************MANIFESTS**************************************************
+
+   MANIFEST: sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0 shares with MANIFEST: sha256:3271612b344ab8807de8517b62c2dc07a65e3fdc2c703bf0bf3991b2f0604b0d:
+       []
+       NOT SHARED:2
+   MANIFEST: sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0 shares with MANIFEST: sha256:a56c2ade65aa090035aa70ac19d5a99606d2965a0782043ab332271be0c73eb4:
+       [BLOB: sha256:df5f2171d7a00260c6910231fd760f7b7d2afa576d1f2a674bf84496f1374e76]
+       NOT SHARED:1
+   MANIFEST: sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0 shares with MANIFEST: sha256:04c27eb360809e1ea49c97fe8b8ca21d9f0ca7eb1be98030d1b539a76613470d:
+       []
+       NOT SHARED:2
+   MANIFEST: sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0 shares with MANIFEST: sha256:b3afe9268760e106cd93782354bdd24a192fec3f910289d7ff4233665af95f9d:
+       []
+       NOT SHARED:2
+   MANIFEST: sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0 shares with MANIFEST: sha256:c5fc921c8a971793134160bc3ccc50454d7ba67aea36da44c74e91f8287216c6:
+       []
+       NOT SHARED:2
+   MANIFEST: sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0 shares with MANIFEST: sha256:b16ece3182c8386ab1fd001f4c69edaf984c728ad3561ba24d9e93193eb8e8c0:
+       [BLOB: sha256:df5f2171d7a00260c6910231fd760f7b7d2afa576d1f2a674bf84496f1374e76, BLOB: sha256:59add7b26d3a179ea3f653e7d4bb81250611f1408eb1effb2e50631a9da145c4]
+       NOT SHARED:0

--- a/pulp2/tools/pulp-docker-inspector/pulp-docker-inspector.py
+++ b/pulp2/tools/pulp-docker-inspector/pulp-docker-inspector.py
@@ -1,0 +1,219 @@
+"""
+A tool to explore the relationships in a local docker repository.
+"""
+
+import argparse
+import json
+import sys
+
+from requests.auth import HTTPBasicAuth
+import requests
+
+AUTH = HTTPBasicAuth('admin', 'admin')
+BASE_URL = 'https://pulp2.dev/pulp/api/v2'
+
+
+class RepoContent():
+    """Model a repository and all docker content within it."""
+
+    def __init__(self, repo_id):
+        """Register docker content of all types and make the lists accessible."""
+        self.name = repo_id
+
+        tag_dicts = retrieve_relationship_info(repo_id, "docker_tag")
+        self.tags = [Tag(tag_dict, self) for tag_dict in tag_dicts]
+
+        ml_dicts = retrieve_relationship_info(repo_id, "docker_manifest_list")
+        self.manifest_lists = [ManifestList(ml_dict, self) for ml_dict in ml_dicts]
+
+        manifest_dicts = retrieve_relationship_info(repo_id, "docker_manifest")
+        self.manifests = [Manifest(manifest_dict, self) for manifest_dict in manifest_dicts]
+
+        blob_dicts = retrieve_relationship_info(repo_id, "docker_blob")
+        self.blobs = [Blob(blob_dict, self) for blob_dict in blob_dicts]
+
+    def print_top_down(self):
+        """Recursively print the content of a repository, showing the content relations."""
+        print("REPO: {name}".format(name=self.name))
+        for tag in self.tags:
+            tag.print_top_down()
+
+
+class Tag():
+    """Dummy model for Docker Tags."""
+
+    def __init__(self, tag_dict, repo):
+        """Extract relevant info for a tag."""
+        self.repo = repo
+        self.name = tag_dict['metadata']['name']
+        self.manifest_digest = tag_dict['metadata']['manifest_digest']
+        self.manifest_type = tag_dict['metadata']['manifest_type']
+        self.schema_version = tag_dict['metadata']['schema_version']
+
+    @property
+    def manifests_and_mls(self):
+        """Manifests and Manifest Lists can be treated the same for tags. Retrieve both."""
+        mls = [ml for ml in self.repo.manifest_lists if ml.digest == self.manifest_digest]
+        manifests = [man for man in self.repo.manifests if man.digest == self.manifest_digest]
+        return mls + manifests
+
+    def __repr__(self):
+        """Tags can be referenced by name."""
+        return "TAG: {name}".format(name=self.name)
+
+    def print_top_down(self):
+        """Recursively print the content related to this tag, showing the content relations."""
+        print(self)
+        for tagged in self.manifests_and_mls:
+            tagged.print_top_down(tab=4)
+
+    def print_relations(self):
+        """Recursively show relations of the tagged content."""
+        print(self)
+        for tagged in self.manifests_and_mls:
+            tagged.print_relations()
+
+
+class ManifestList():
+    """Dummy model for Docker Manifest Lists."""
+
+    def __init__(self, ml_dict, repo):
+        """Create a dummy Docker Manifest List."""
+        self.repo = repo
+        self.digest = ml_dict['metadata']['digest']
+        self._manifest_digests = [man['digest'] for man in ml_dict['metadata']['manifests']]
+
+    def print_relations(self, other):
+        """Recursively show relations of the manifest list."""
+        print("{self} shares with {other}:".format(self=self, other=other))
+        print("    " + str([man for man in self.manifests if man in other.manifests]))
+        print("    NOT SHARED:" + str(len(
+            [man for man in self.manifests if man not in other.manifests]
+        )))
+
+    @property
+    def manifests(self):
+        """Retrieve manifests associated with this Manifest List."""
+        return [man for man in self.repo.manifests if man.digest in self._manifest_digests]
+
+    def __repr__(self):
+        """Manifest Lists can be referenced by sha256 digest."""
+        return "MANIFESTLIST: {digest}".format(digest=self.digest)
+
+    def print_top_down(self, tab=None):
+        """Recursively print the content related to this manifest list, showing the relations."""
+        print(" " * tab + repr(self))
+        if not tab:
+            tab = 0
+        for manifest in self.manifests:
+            manifest.print_top_down(tab=tab+4)
+
+
+class Manifest():
+    """Dummy model for Docker Manifests."""
+
+    def __init__(self, manifest_dict, repo):
+        """Create a dummy Docker Manifest."""
+        self.repo = repo
+        self.digest = manifest_dict['metadata']['digest']
+        self._blob_sums = [layer['blob_sum'] for layer in manifest_dict['metadata']['fs_layers']]
+        self.config_digest = None
+
+        if manifest_dict['metadata']['schema_version'] == 2:
+            self.config_digest = manifest_dict['metadata']['config_layer']
+
+    def __repr__(self):
+        """Manifests can be referenced by sha256 digest."""
+        return "MANIFEST: {digest}".format(digest=self.digest)
+
+    @property
+    def blobs(self):
+        """Retrieve blobs associated with this Manifest."""
+        blobs = [blob for blob in self.repo.blobs if blob.digest in self._blob_sums]
+        config_blobs = [blob for blob in self.repo.blobs if blob.digest == self.config_digest]
+        return blobs + config_blobs
+
+    def print_top_down(self, tab=None):
+        """Recursively print the content related to this manifest, showing the content relations."""
+        if not tab:
+            tab = 0
+        print(" " * tab + repr(self))
+        for blob in self.blobs:
+            blob.print_top_down(tab=tab+4)
+
+    def print_relations(self, other):
+        """Recursively show relations of the manifest."""
+        print("{self} shares with {other}:".format(self=self, other=other))
+        print("    " + str([blob for blob in self.blobs if blob in other.blobs]))
+        print("    NOT SHARED:" + str(len(
+            [blob for blob in self.blobs if blob not in other.blobs]
+        )))
+
+
+class Blob():
+    """Dummy model for Docker Blobs (aka layers)."""
+
+    def __init__(self, blob_dict, repo):
+        """Create a dummy Docker Blob."""
+        self.repo = repo
+        self.digest = blob_dict['metadata']['digest']
+
+    def __repr__(self):
+        """Blobs can be referenced by sha256 digest."""
+        return "BLOB: {digest}".format(digest=self.digest)
+
+    def print_top_down(self, tab=None):
+        """Recursively print the content related to this manifest, showing the content relations."""
+        if not tab:
+            tab = 0
+        print(" " * tab + repr(self))
+
+
+def retrieve_relationship_info(repo_id, content_type):
+    """Hit the Pulp API and retrieve content info by type."""
+    criteria = {"type_ids": [content_type], "filters": {}}
+    req = requests.post(
+        url='{base}/repositories/{repo}/search/units/'.format(base=BASE_URL, repo=repo_id),
+        data=json.dumps({"criteria": criteria}),
+        auth=AUTH,
+    )
+    return json.loads(req.content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Map the contents of a docker repo.')
+    parser.add_argument('repo_id')
+    parser.add_argument("--list", action="store_true")
+    parser.add_argument("--relation")
+    args = parser.parse_args()
+    test_repo = RepoContent(args.repo_id)
+    if args.list:
+        test_repo.print_top_down()
+    if args.relation:
+        this = None
+        for ml in test_repo.manifest_lists:
+            if ml.digest == args.relation:
+                this = ml
+                break
+        if this:
+            print
+            print("********************MANIFEST_LISTS*********************************************")
+            print
+            for other_ml in test_repo.manifest_lists:
+                this.print_relations(other_ml)
+            sys.exit(0)
+
+        for manifest in test_repo.manifests:
+            if manifest.digest == args.relation:
+                this = manifest
+                break
+        if this:
+            print
+            print("********************MANIFESTS**************************************************")
+            print
+            for other_manifest in test_repo.manifests:
+                this.print_relations(other_manifest)
+            sys.exit(0)
+        else:
+            print("NOT FOUND {dig}".format(dig=args.relation))
+            sys.exit(1)


### PR DESCRIPTION
This tool inspects a pulp docker repo and shows the relationships between the content. It can be used to easily show which manifest lists/manifests share manifests/blobs with other content.