### PR TITLE
Add lsof to Pulp 3 installer

### DIFF
--- a/pulp3/install_pulp3/install-pulp-from-source.yml
+++ b/pulp3/install_pulp3/install-pulp-from-source.yml
@@ -91,11 +91,12 @@
               - iotop
               - jnettop
               - jq
+              - lsof
               - ncdu
               - tmux
               - tree
-              - wget
               - vim
+              - wget
             state: present
           retries: 5
           register: result


### PR DESCRIPTION
Add lsof to Pulp 3 installer. It is required by certain tests related to
file descriptors.